### PR TITLE
Add tests without modifying original script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.xls
 *.xlsx
 __pycache__/
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.csv
 *.xls
 *.xlsx
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# List Comparison
+
+This project provides functions to compare lists and output CSV files.
+
+## Running Tests
+
+The test suite uses `pytest`. To run the tests, execute:
+
+```bash
+pytest
+```
+
+This command discovers tests in the `tests/` directory and executes them.

--- a/tests/test_list_comparison.py
+++ b/tests/test_list_comparison.py
@@ -1,0 +1,38 @@
+import csv
+import os
+import types
+import pathlib
+
+# Load the list-comparison module while skipping the trailing invocation of
+# `list_comparison()` so that no interactive prompts execute during import.
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / 'list-comparison.py'
+source_lines = MODULE_PATH.read_text().splitlines()
+module_source = "\n".join(source_lines[:-1])
+list_comparison = types.ModuleType("list_comparison")
+exec(module_source, list_comparison.__dict__)
+
+
+def test_unique_elements():
+    result = list_comparison.unique_elements([1, 2, 3], [3, 4, 5])
+    assert result["list_one"] == [1, 2]
+    assert result["list_two"] == [4, 5]
+
+
+def test_intersection_elements():
+    assert list_comparison.intersection_elements([1, 2, 3], [3, 4]) == [3]
+
+
+def test_union_elements():
+    assert list_comparison.union_elements([1, 2], [2, 3]) == [1, 2, 3]
+
+
+def test_output_elements(tmp_path):
+    out_file = tmp_path / "out.csv"
+    list_comparison.output_elements(["a", "b"], "header", out_file)
+    with open(out_file, newline="") as f:
+        rows = list(csv.reader(f))
+    assert rows == [["h", "e", "a", "d", "e", "r"], ["a"], ["b"]]
+
+
+def test_read_file_nonexistent():
+    assert list_comparison.read_file("nonexistent_file.csv") == ""


### PR DESCRIPTION
## Summary
- revert earlier changes to `list-comparison.py`
- adjust tests to import the script without executing it
- expect existing behaviour from `output_elements` and `read_file`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684b6128a9208329b40f00d019759b56